### PR TITLE
PasswordChar option for TextBox

### DIFF
--- a/ConsoleFramework/Controls/TextBox.cs
+++ b/ConsoleFramework/Controls/TextBox.cs
@@ -168,6 +168,8 @@ namespace ConsoleFramework.Controls {
             set;
         }
 
+        public char? PasswordChar { get; set; }
+
         private int getSize( ) {
             if ( Size.HasValue ) return Size.Value;
             return text != null ? text.Length + 1 : 1;
@@ -193,7 +195,7 @@ namespace ConsoleFramework.Controls {
             if (null != text) {
                 for (int i = displayOffset; i < text.Length; i++) {
                     if (i - displayOffset < ActualWidth - 2 && i - displayOffset >= 0) {
-                        buffer.SetPixel(1 + i - displayOffset, 0, text[i]);
+                        buffer.SetPixel(1 + i - displayOffset, 0, PasswordChar.HasValue ? PasswordChar.Value : text[i]);
                     }
                 }
             }

--- a/ConsoleFramework/Xaml/XamlParser.cs
+++ b/ConsoleFramework/Xaml/XamlParser.cs
@@ -597,6 +597,10 @@ namespace Xaml {
             if (source == typeof(string) && dest == typeof(int?)) {
                 return int.Parse((string) value);
             }
+            if (source == typeof(string) && dest == typeof(char?))
+            {
+                return string.IsNullOrEmpty((string) value) ? (char?) null : ((string) value)[0];
+            }
 
             // Process TypeConverterAttribute attributes if exist
             if (Type.GetTypeCode(source) == TypeCode.Object) {


### PR DESCRIPTION
An option to specify PasswordChar property in TextBox, so a value's characters get replaced by chosen character. Useful for password text boxes. If not set, TextBox shows a value as usual. 